### PR TITLE
feat: add `batch()` method

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -532,7 +532,7 @@ export class Api {
 	 * @param {(batchApi: IBatchApi) => string[]} uriCollector   A function which will be invoked with api instance. 
      *     This instance is special, as all methods there return a url string instead of making a backend call. 
      *     `uriCollector` should return an array of uris to be executed in batch.
-     *     So, for example, one may return `[IBatchApi.metadata(), IBatchApi.count(...)]` from `uriCollector`.
+     *     So, for example, one may return `[batchApi.metadata(), batchApi.count(...)]` from `uriCollector`.
      *     That will mean `call metadata() method` and then `call count() method`. 
      *     
 	 * @param {boolean} isAtomic    Pass true if you want all operations to happen in the same transaction.

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -721,22 +721,6 @@ function batchApiFactory(api: Api): IBatchApi {
 	}
 }
 
-//
-// export type IBatchApi = Pick<Api, 
-// 	'copy' |
-// 	'count' | 
-// 	'create' |
-// 	'edit' | 
-// 	'editMultiple' | 
-// 	'execute' | 
-// 	'get' | 
-// 	'metadata' | 
-// 	'namedQuery' | 
-// 	'remove' | 
-// 	'report' | 
-// 	'request' | 
-// 	'search' 
-// >
 
 export type TSuccessHandler<T = any> = (response: any) => Promise<T>
 export type TFailureHandler = (err: any) => never

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -540,9 +540,9 @@ export class Api {
      *     
 	 * @returns {Promise<any[] | undefined>}    
 	 */
-	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic: false): Promise<any[]>
-	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic: true): Promise<undefined>
-	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic: boolean): Promise<any[] | undefined> {
+	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic?: false): Promise<any[]>
+	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic?: true): Promise<undefined>
+	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic?: boolean): Promise<any[] | undefined> {
 		if (this._uriGenerationMode) {
 			throw new Error('This method is not supported in batch mode')
 		}

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -110,10 +110,7 @@ export class Api {
      * @return {Promise}    A promise which will resolved with API key if everything went ok and rejected otherwise
      */
     getApiKey(username: string, password: string): Promise<string> {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
-        return new Promise((resolve, reject) => {
+		return new Promise((resolve, reject) => {
             if (typeof this._httpOptions.headers.apiKey !== 'undefined') {
                 resolve(this._httpOptions.headers.apiKey)
             }
@@ -188,10 +185,7 @@ export class Api {
      * @return {Promise}    A promise which will resolved if everything went ok and rejected otherwise
      */
     clearApiKey() {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
-        return new Promise((resolve, reject) => {
+		return new Promise((resolve, reject) => {
             const req = this.execute('USER', null, 'clearApiKey') as Promise<any>
             req.then((result) => {
                 if (result) {
@@ -307,9 +301,6 @@ export class Api {
      * @return {Promise}    A promise which will resolved with logged in user data if everything went ok and rejected otherwise
      */
     login(username: string, password: string) {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
 		const req = this.request('login', {username: username, password: password}, null, Api.Methods.POST)
         return (req as Promise<any>).then((data) => {
             this.setSessionID(data.sessionID)
@@ -323,10 +314,7 @@ export class Api {
      * @return {Promise}    A promise which will resolved if everything went ok and rejected otherwise
      */
     logout(): Promise<undefined> {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
-        return new Promise((resolve, reject) => {
+		return new Promise((resolve, reject) => {
             const req = this.request('logout', null, null, Api.Methods.GET);
             (req as Promise<any>).then((result) => {
                 if (result && result.success) {
@@ -512,9 +500,6 @@ export class Api {
     search(objCode: string, query?: object, fields?: TFields, useHttpPost = false) {
         let searchQuery, method
         if (useHttpPost) {
-			if (this._uriGenerationMode) {
-				throw new Error('Using useHttpPost=true is not supported in batch mode for this method')
-			}
             searchQuery = objectAssign({}, query, {method: Api.Methods.GET})
             method = Api.Methods.POST
         }
@@ -543,9 +528,6 @@ export class Api {
 	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic?: false): Promise<any[]>
 	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic?: true): Promise<undefined>
 	batch(uriCollector: (batchApi: IBatchApi) => string[], isAtomic?: boolean): Promise<any[] | undefined> {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
 		const batchApi = batchApiFactory(this)
         const uris = uriCollector(batchApi)
         if (uris.length === 0) {
@@ -574,9 +556,6 @@ export class Api {
      * @return {string} returns the given api key value
      */
     setApiKey(apiKey) {
-        if (this._uriGenerationMode) {
-            throw new Error('This method is not supported in batch mode')
-        }
         return this._httpOptions.headers.apiKey = apiKey
     }
 
@@ -586,10 +565,7 @@ export class Api {
      * @param {String|undefined} sessionID   sessionID to set
      */
     setSessionID(sessionID) {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
-        if (sessionID) {
+		if (sessionID) {
             this._httpOptions.headers.sessionID = sessionID
         }
         else {
@@ -603,10 +579,7 @@ export class Api {
      * @param {String|undefined} xsrfToken   X-XSRF-TOKEN to set
      */
     setXSRFToken(xsrfToken?: string) {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
-        if (xsrfToken) {
+		if (xsrfToken) {
             this._httpOptions.headers['X-XSRF-TOKEN'] = xsrfToken
         }
         else {
@@ -626,19 +599,13 @@ export class Api {
      * @param {String} filename Override the filename
      */
     uploadFromStream(stream: Readable, filename: string) {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
-        const data = new NodeFormData()
+		const data = new NodeFormData()
         data.append('uploadedFile', stream, filename)
         return this.request('upload', data, null, Api.Methods.POST)
     }
 
     uploadFileContent(fileContent, filename: string) {
-		if (this._uriGenerationMode) {
-			throw new Error('This method is not supported in batch mode')
-		}
-        const data = new GlobalScope.FormData()
+		const data = new GlobalScope.FormData()
         data.append('uploadedFile', fileContent, filename)
         return this.request('upload', data, null, Api.Methods.POST)
     }

--- a/test/integration/batch.spec.ts
+++ b/test/integration/batch.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015 Workfront
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fetchMock from 'fetch-mock'
+import should from 'should'
+
+import * as Workfront from '../../src/index'
+
+const API_URL = 'http://foobar:8080'
+
+describe('Batch', function() {
+
+    afterEach(fetchMock.reset)
+    afterEach(fetchMock.restore)
+
+    beforeEach(function() {
+        this.api = new Workfront.Api({
+            url: API_URL
+        })
+    })
+    afterEach(function() {
+        this.api = undefined
+    })
+
+	beforeEach(function() {
+		fetchMock.mock(
+			`begin:${API_URL}/attask/api`,
+			200,
+			{
+				name: 'any'
+			}
+		)
+	})
+
+	it('should not make any network calls in uriCollector callback', function() {
+		this.api.batch(
+            batchApi => [
+				batchApi.copy('foo', 'bar', {name: 'Copy of bar'}),
+				batchApi.count('USER', {}),
+				batchApi.create('baz', {
+					foo: 'bar'
+				}, ['*', 'zzz:*']),
+				batchApi.edit('PROJ', 'foobar', {
+					name: 'api test 2'
+				}),
+				batchApi.execute('foo', 'bar', 'baz'),
+				batchApi.get('foo', 'bar'),
+                batchApi.metadata('TASK', ['collections']),
+				batchApi.namedQuery('foo', 'action'),
+				batchApi.remove('foo', 'objID'),
+				batchApi.report('task', {
+					'status_GroupBy': true
+				}),
+				batchApi.search('role', {
+					'status_GroupBy': true
+				})
+			],
+            false
+        )
+        should(fetchMock.calls().matched.length).equal(1)
+	})
+})


### PR DESCRIPTION
Example usage:

```typescript
api.batch((batchApi) => {
  return [
    batchApi.count('USER', {}),
    batchApi.metadata('TASK', ['collections'])
  ]
}, false)
  .then(function(results) {
    // results is an array of 2 elements:
    // results[0] - contains `{count: 24}`
    // results[1] - contains metadata for collection properties of TASK api object
  })
```