### PR TITLE
fix: exports Api and NodeApi for NodeJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const Workfront = require('workfront-api')
 /**
  * The console.log statement below will output the following:
  * {
- *    NodeApi: [Function: Api],
+ *    Api: [Function: Api],
  *    ResponseHandler: { success: [Function: success], failure: [Function: failure] }
  * }
  */

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typings"
   ],
   "sideEffects": false,
-  "typings": "typings/Api.d.ts",
+  "typings": "typings/node.d.ts",
   "dependencies": {
     "@types/node": "^17.0.8",
     "form-data": "^4.0.0",

--- a/src/node.ts
+++ b/src/node.ts
@@ -16,7 +16,7 @@
 import * as NodeFormData from 'form-data'
 import 'isomorphic-fetch'
 import {Readable} from 'stream'
-import {Api as BaseApi, makeFetchCall} from './Api'
+import {Api as BaseApi, makeFetchCall, ResponseHandler} from './Api'
 
 /**
  * Starting from version 2.0 API allows users to upload files.
@@ -29,7 +29,7 @@ import {Api as BaseApi, makeFetchCall} from './Api'
  * @param {fs.ReadStream} stream    A readable stream with file contents
  * @param {String} filename Override the filename
  */
-export class NodeApi extends BaseApi {
+class NodeApi extends BaseApi {
     constructor(options) {
         super(options)
     }
@@ -45,6 +45,10 @@ export class NodeApi extends BaseApi {
     }
 }
 
-export {ResponseHandler} from './Api'
+export {ResponseHandler, NodeApi, NodeApi as Api, makeFetchCall}
 
-export {NodeApi as Api}
+export default {
+    NodeApi,
+    ResponseHandler,
+    Api: NodeApi,
+}

--- a/test/Api.spec.ts
+++ b/test/Api.spec.ts
@@ -15,11 +15,11 @@
  */
 import * as should from 'should'
 
-import {NodeApi} from '../src/node'
+import {Api} from '../'
 
 describe('Create new instance for API', function () {
     it('should have methods', function () {
-        const api = new NodeApi({url: 'http://localhost'})
+        const api = new Api({url: 'http://localhost'})
         should(api.copy).be.a.Function().and.has.lengthOf(5)
         should(api.count).be.a.Function().and.has.lengthOf(2)
         should(api.create).be.a.Function().and.has.lengthOf(3)
@@ -41,17 +41,17 @@ describe('Create new instance for API', function () {
     })
 
     it('should set correct API path based on passed configuration (version is passed)', function () {
-        const api = new NodeApi({url: 'http://localhost', version: '2.0'})
+        const api = new Api({url: 'http://localhost', version: '2.0'})
         should(api._httpOptions.path).equal('/attask/api/v2.0')
     })
 
     it('should set correct API path based on passed configuration (version is not passed)', function () {
-        const api = new NodeApi({url: 'http://localhost'})
+        const api = new Api({url: 'http://localhost'})
         should(api._httpOptions.path).equal('/attask/api-internal')
     })
 
     it('should set correct API path based on passed configuration (version="asp")', function () {
-        const api = new NodeApi({url: 'http://localhost', version: 'asp'})
+        const api = new Api({url: 'http://localhost', version: 'asp'})
         should(api._httpOptions.path).equal('/attask/api-asp')
     })
 })

--- a/test/module.spec.ts
+++ b/test/module.spec.ts
@@ -1,0 +1,18 @@
+import * as should from 'should'
+import * as cjsModule from '../'
+
+describe('Verify workfront-api cjs exported members', function () {
+    it('exports cjs required members', function () {
+        should(cjsModule).properties('Api', 'ResponseHandler', 'makeFetchCall')
+    })
+    it('has NodeApi as Api fallback', function () {
+        should(cjsModule).properties('Api', 'NodeApi')
+        should(cjsModule.Api).equals(cjsModule.NodeApi)
+    })
+    it('exports "default" for backward compatibility', function () {
+        should(cjsModule).properties('default')
+        should(cjsModule.default).property('Api', cjsModule.Api)
+        should(cjsModule.default).property('NodeApi', cjsModule.NodeApi)
+        should(cjsModule.default).property('ResponseHandler', cjsModule.ResponseHandler)
+    })
+})


### PR DESCRIPTION
Review the exported members for the CommonJS format.  
For NodeJS there will be the following exported members;
- `Api` - the Api class for NodeJS, previously known as NodeApi,
- `NodeApi` - same as above, keeping it for backward compatibility,
- `ResponseHandler` - an object containing `success` and `failure` callbacks,
- `makeFetchCall` - a function that makes the request bound with the ResponseHandler,
- `default` - exports `Api`, `NodeApi`, and `ResponseHandler` for backward compatibility purpose only.

Closes #1035.