### PR TITLE
Added IMS Token support to the package

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -21,6 +21,11 @@
 
 import {INTERNAL_PREFIX} from '@workfront/api-constants'
 
+export interface IImsCredentials {
+    imsToken: string
+    imsOrgId: string
+}
+
 export interface IHttpOptions {
     path?: string
     method?: string
@@ -30,6 +35,8 @@ export interface IHttpOptions {
         sessionID?: string
         'X-XSRF-TOKEN'?: string
         apiKey?: string
+        Authorization?: string
+        'x-gw-ims-org-id'?: string
     }
 }
 export interface IApiConfig {
@@ -575,6 +582,20 @@ export class Api {
             delete this._httpOptions.headers['X-XSRF-TOKEN']
         }
     }
+    /**
+     * Sets the 'x-gw-ims-org-id' and 'Authorization' header
+     * @memberof Api
+     * @param {IImsCredentials} imsCredentials ims token and ims org id to set
+     */
+    setImsCredentials(imsCredentials?: IImsCredentials) {
+        if (imsCredentials) {
+            this._httpOptions.headers.Authorization = 'Bearer ' + imsCredentials.imsToken
+            this._httpOptions.headers['x-gw-ims-org-id'] = imsCredentials.imsOrgId
+        } else {
+            delete this._httpOptions.headers.Authorization
+            delete this._httpOptions.headers['x-gw-ims-org-id']
+        }
+    }
 
     uploadFileContent(fileContent, filename: string) {
         const data = new FormData()
@@ -591,6 +612,12 @@ export class Api {
             headers.append('X-XSRF-TOKEN', this._httpOptions.headers['X-XSRF-TOKEN'])
         } else if (this._httpOptions.headers.apiKey) {
             headers.append('apiKey', this._httpOptions.headers.apiKey)
+        } else if (
+            this._httpOptions.headers.Authorization &&
+            this._httpOptions.headers['x-gw-ims-org-id']
+        ) {
+            headers.append('Authorization', this._httpOptions.headers.Authorization)
+            headers.append('x-gw-ims-org-id', this._httpOptions.headers['x-gw-ims-org-id'])
         }
         return headers
     }

--- a/test/Api.spec.ts
+++ b/test/Api.spec.ts
@@ -38,6 +38,7 @@ describe('Create new instance for API', function () {
         should(api.uploadFileContent).be.a.Function().and.has.lengthOf(2)
         should(api.setApiKey).be.a.Function().and.has.lengthOf(1)
         should(api.clearApiKey).be.a.Function().and.has.lengthOf(0)
+        should(api.setImsCredentials).be.a.Function().and.has.lengthOf(1)
     })
 
     it('should set correct API path based on passed configuration (version is passed)', function () {
@@ -53,5 +54,17 @@ describe('Create new instance for API', function () {
     it('should set correct API path based on passed configuration (version="asp")', function () {
         const api = new Api({url: 'http://localhost', version: 'asp'})
         should(api._httpOptions.path).equal('/attask/api-asp')
+    })
+
+    it('should store IMS headers when credentials are set', function () {
+        const api = new Api({url: 'http://localhost'})
+        api.setImsCredentials({imsToken: 'abc123', imsOrgId: 'org-1'})
+
+        should(api._httpOptions.headers.Authorization).equal('Bearer abc123')
+        should(api._httpOptions.headers['x-gw-ims-org-id']).equal('org-1')
+
+        const headers = (api as any).getHeaders()
+        should(headers.get('Authorization')).equal('Bearer abc123')
+        should(headers.get('x-gw-ims-org-id')).equal('org-1')
     })
 })


### PR DESCRIPTION
- Added optional IMS token support when creating the client.
- When an IMS token is provided, it is sent as an `Authorization: Bearer <token>` header.
- Existing SessionID and ApiKey authentication remain unchanged, ensuring full backward compatibility.
